### PR TITLE
Fixed issue with iOS patterns

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,7 +37,7 @@ class VibratingApp extends StatelessWidget {
 
                       Scaffold.of(context).showSnackBar(snackBar);
                       Vibration.vibrate(
-                          pattern: [500, 1000, 1000, 2000, 500, 3000, 500, 500]);
+                          pattern: [500, 1000, 500, 2000, 500, 3000, 500, 500]);
                     },),
                     RaisedButton(
                     child: Text('Vibrate with pattern and amplitude'),
@@ -50,7 +50,7 @@ class VibratingApp extends StatelessWidget {
                       Scaffold.of(context).showSnackBar(snackBar);
                       Vibration.vibrate(
                           pattern: [500, 1000, 500, 2000, 500, 3000, 500, 500],
-                          intensities: [100, 200, 0, 128, 255, 0, 128, 255]);
+                          intensities: [128, 255, 64, 255]);
                     },
 
                   )


### PR DESCRIPTION
The problem had to do with how the engine was being initialized. I'm not exactly sure why it was an issue, but moving the engine registration code to the `register` function fixed it.

I also cleaned up the code a bit: 
1. removed the nested "if"s in favor of "guard"
2. increased code reuse (just one while loop instead of two)

Let me know if you face any issues :) Happy to make more changes.

NOTE: the simple `Vibration.vibrate(duration: 1000);` does not take duration into account and that was a problem before these changes. I did not address that issue here.